### PR TITLE
Update Guidelines.md

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1,12 +1,16 @@
 This document contains general guidelines for the creation of design patterns (DP), especially in the context of the BFO and CCO communities. The intent of DPs as understood in this document are numerous: they act as documentation for the ontology, insofar as they show how the resources in the ontology can be correctly used. They also provide a reusable template that can be implemented in a system using ontologies, for example to guide instantiation or to write SPARQL queries that look for the presence of a certain structure. The current status of the guidelines discussed and adopted in the NCOR CCO working group are the following:
 
-- The DP needs to have a clear and understandable legend.
-- The DP needs to represent a graph structure of instances related to each other using relations from the ontology itself or from vocabularies such as RDF, OWL, etc. 
-- The DP needs to clearly and unambiguously distinguish between classes, instances, relations and data. For example, by using different colors or shapes in the graph.
-- Relations shall be represented as edges, while classes and instances are to be represented as nodes.
-- The DP needs to label relations with the exact terminology taken by the ontology. If the ontology uses opaque IRIs, it is preferable to also add them.
-- The DP needs to label classes with the exact terminology taken by the ontology. If the ontology uses opaque IRIs, it is preferable to also add them.
-- The DP needs to have instances named with human-readable names (such as the ones that one would use in a human-readable label). For example, "John" can serve as the name of an instance of class "Person". 
-- Instance names serve the purpose of providing an example of what in the world the class structure could be used to represent. Nevertheless, it is up to the author of the DP to make it clear that the structure can be reused for different cases as well.
-- The class structure will be specified at the most general level. For example, a DP illustrating specific dependence will use the class "Specifically Dependent Continuant", and not the class "Quality" or "Role"
-- All instances should have at least one parent class to make it clear where it fits in the BFO/CCO hierarchy.
+1. The DP needs to have a clear and understandable legend.
+2. The DP needs to represent a graph structure of instances related to each other using relations from the ontology itself or from web languages such as RDF, OWL, etc. 
+3. The DP needs to clearly and unambiguously distinguish between classes, instances, relations and data. For example, by using different colors or shapes in the graph.
+4. Relations shall be represented as edges, while classes and instances are to be represented as nodes.
+5. All instances should have at least one parent class to make it clear where it fits in the BFO/CCO hierarchy. Moreover, that parent class should be the most specific available for that instance. For example, 
+6. When the focus of the design pattern is explaning a relation, its more general domain and range classes must be used. For example, a DP illustrating the relation "bfo:specifically dependends on" will use the class "bfo:Specifically Dependent Continuant" as the domain and "bfo:Independent Continunat" as the range, and not the classes "bfo:Quality" or "bfo:Material Entity", which are children of "bfo:Specifically Dependent Continuant" and "bfo:Independent Continunat", respectively.  
+7. The DP needs to label relations with the exact rdfs:label taken by the ontology, plus the prefix of the ontology (i.e. "cco:agent in"). 
+8. The DP needs to label classes with the exact rdfs:label taken by the ontology, plus the prefix of the ontology (i.e. "cco:Civilian Role"). On a seconf line of the class node, add the URI of the class too.
+9. The DP needs to have instances named with human-readable names, contrasted to mere acronyms or codes, if possible. For example, "John" can serve as the name of an instance of class "cco:Person". 
+10. Always use number IDs at the end of lower case instance names, like "person 1" or "sledge 33", if no proper names for instances are available, like "Charles L. Kane" for a person, or "Rosebud" for a sledge.
+11. Instance names serve the purpose of providing an example of what in the world the class structure could be used to represent. Nevertheless, it is up to the author of the DP to make it clear that the structure can be reused for different cases as well.
+12. Preferebly, the design pattern should be uploaded as a markup code file (e.g. Mermaid) and as a high quality image file displayable on Github. The minimum is having the image file.
+
+

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1,16 +1,16 @@
 This document contains general guidelines for the creation of design patterns (DP), especially in the context of the BFO and CCO communities. The intent of DPs as understood in this document are numerous: they act as documentation for the ontology, insofar as they show how the resources in the ontology can be correctly used. They also provide a reusable template that can be implemented in a system using ontologies, for example to guide instantiation or to write SPARQL queries that look for the presence of a certain structure. The current status of the guidelines discussed and adopted in the NCOR CCO working group are the following:
 
 1. The DP needs to have a clear and understandable legend.
-2. The DP needs to represent a graph structure of instances related to each other using relations from the ontology itself or from web languages such as RDF, OWL, etc. 
+2. The DP needs to represent a graph structure of instances related to each other using relations from the ontology itself or from web languages such as XML/RDF, OWL, etc. 
 3. The DP needs to clearly and unambiguously distinguish between classes, instances, relations and data. For example, by using different colors or shapes in the graph.
 4. Relations shall be represented as edges, while classes and instances are to be represented as nodes.
 5. All instances should have at least one parent class to make it clear where it fits in the BFO/CCO hierarchy. 
-6. When the focus of the design pattern is explaning a relation, its more general domain and range classes must be used. For example, a DP illustrating the relation "bfo:specifically dependends on" will use the class "bfo:Specifically Dependent Continuant" as the domain and "bfo:Independent Continunat" as the range, and not the classes "bfo:Quality" or "bfo:Material Entity", which are children of "bfo:Specifically Dependent Continuant" and "bfo:Independent Continunat", respectively.  
+6. When the focus of the DP is explaning a relation, its more general domain and range classes must be used. For example, a DP illustrating the relation "bfo:specifically dependends on" will use the class "bfo:Specifically Dependent Continuant" as the domain and "bfo:Independent Continunat" as the range, and not the classes "bfo:Quality" or "bfo:Material Entity", which are children of "bfo:Specifically Dependent Continuant" and "bfo:Independent Continunat", respectively.  
 7. The DP needs to label relations with the exact rdfs:label taken by the ontology, plus the prefix of the ontology (i.e. "cco:agent in"). On a second line of the class node, add the URI of the relation too.
 8. The DP needs to label classes with the exact rdfs:label taken by the ontology, plus the prefix of the ontology (i.e. "cco:Civilian Role"). On a second line of the class node, add the URI of the class too.
 9. The DP needs to have instances named with human-friendly names, contrasted to mere acronyms or codes, if possible. For example, "John" can serve as the name of an instance of class "cco:Person". 
 10. Always use number IDs at the end of lower case instance names, like "person 1" or "sledge 33", if no proper names for instances are available, like "Charles L. Kane" for a person, or "Rosebud" for a sledge.
 11. Instance names serve the purpose of providing an example of what in the world the class structure could be used to represent. Nevertheless, it is up to the author of the DP to make it clear that the structure can be reused for different cases as well.
-12. Preferebly, the design pattern should be uploaded as a markup code file (e.g. Mermaid) and as a high quality image file displayable on Github. The minimum is having the image file.
+12. Preferebly, the DP should be uploaded as a markup code file (e.g. Mermaid) and as a high quality image file displayable on Github. The minimum is having the image file.
 
 

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -4,11 +4,11 @@ This document contains general guidelines for the creation of design patterns (D
 2. The DP needs to represent a graph structure of instances related to each other using relations from the ontology itself or from web languages such as RDF, OWL, etc. 
 3. The DP needs to clearly and unambiguously distinguish between classes, instances, relations and data. For example, by using different colors or shapes in the graph.
 4. Relations shall be represented as edges, while classes and instances are to be represented as nodes.
-5. All instances should have at least one parent class to make it clear where it fits in the BFO/CCO hierarchy. Moreover, that parent class should be the most specific available for that instance. For example, 
+5. All instances should have at least one parent class to make it clear where it fits in the BFO/CCO hierarchy. 
 6. When the focus of the design pattern is explaning a relation, its more general domain and range classes must be used. For example, a DP illustrating the relation "bfo:specifically dependends on" will use the class "bfo:Specifically Dependent Continuant" as the domain and "bfo:Independent Continunat" as the range, and not the classes "bfo:Quality" or "bfo:Material Entity", which are children of "bfo:Specifically Dependent Continuant" and "bfo:Independent Continunat", respectively.  
-7. The DP needs to label relations with the exact rdfs:label taken by the ontology, plus the prefix of the ontology (i.e. "cco:agent in"). 
-8. The DP needs to label classes with the exact rdfs:label taken by the ontology, plus the prefix of the ontology (i.e. "cco:Civilian Role"). On a seconf line of the class node, add the URI of the class too.
-9. The DP needs to have instances named with human-readable names, contrasted to mere acronyms or codes, if possible. For example, "John" can serve as the name of an instance of class "cco:Person". 
+7. The DP needs to label relations with the exact rdfs:label taken by the ontology, plus the prefix of the ontology (i.e. "cco:agent in"). On a second line of the class node, add the URI of the relation too.
+8. The DP needs to label classes with the exact rdfs:label taken by the ontology, plus the prefix of the ontology (i.e. "cco:Civilian Role"). On a second line of the class node, add the URI of the class too.
+9. The DP needs to have instances named with human-friendly names, contrasted to mere acronyms or codes, if possible. For example, "John" can serve as the name of an instance of class "cco:Person". 
 10. Always use number IDs at the end of lower case instance names, like "person 1" or "sledge 33", if no proper names for instances are available, like "Charles L. Kane" for a person, or "Rosebud" for a sledge.
 11. Instance names serve the purpose of providing an example of what in the world the class structure could be used to represent. Nevertheless, it is up to the author of the DP to make it clear that the structure can be reused for different cases as well.
 12. Preferebly, the design pattern should be uploaded as a markup code file (e.g. Mermaid) and as a high quality image file displayable on Github. The minimum is having the image file.


### PR DESCRIPTION
some rephrasing and two additions (the two files upload; numeric IDs for instances). Mind that two rules were also moved up, and all rules were numbered. Most heavy rephrase: the rule mentioning the "specified at the most general level" phrase, which was unclear.